### PR TITLE
添加全息显示参数默认值配置于html文件开头

### DIFF
--- a/templates/40.html
+++ b/templates/40.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>全息图序列查看器 (5x8)</title>
+    <script>
+        // 全息显示参数默认值配置
+        window.HOLOGRAPHY_DEFAULTS = {
+            // 全息显示参数
+            lineNumber: 19.61603,
+            obliquity: 0.101593,
+            deviation: 15.83299625,
+        };
+    </script>
     <style>
         body {
             margin: 0;
@@ -145,7 +154,7 @@
                 <h3>全息显示参数</h3>
                 <div class="control-item">
                     <label for="lineNumber">线数: <span id="lineNumberValue" class="value-display">19.61603</span></label>
-                    <input type="range" id="lineNumber" min="19" max="21" value="19.61603" step="0.00001">
+                    <input type="range" id="lineNumber" min="18" max="21" value="19.61603" step="0.00001">
                 </div>
                 <div class="control-item">
                     <label for="obliquity">倾斜度: <span id="obliquityValue" class="value-display">0.101593</span></label>
@@ -257,6 +266,25 @@
                 });
             });
         });
+        
+        // 将默认值应用到控件（供 init 调用）
+        function applyDefaults() {
+            const d = window.HOLOGRAPHY_DEFAULTS || {};
+
+            // 全息显示参数
+            if (d.lineNumber !== undefined) {
+                document.getElementById('lineNumber').value = d.lineNumber;
+                document.getElementById('lineNumberValue').textContent = d.lineNumber;
+            }
+            if (d.obliquity !== undefined) {
+                document.getElementById('obliquity').value = d.obliquity;
+                document.getElementById('obliquityValue').textContent = d.obliquity;
+            }
+            if (d.deviation !== undefined) {
+                document.getElementById('deviation').value = d.deviation;
+                document.getElementById('deviationValue').textContent = d.deviation;
+            }
+        }
         // WebGL上下文和着色器程序
         let gl;
         let program;
@@ -553,6 +581,9 @@
             getUniforms();
             setupGeometry();
             setupControls();
+
+            // 应用文件顶部的默认值配置
+            applyDefaults();
             
             gl.clearColor(0.0, 0.0, 0.0, 1.0);
             

--- a/templates/depth.html
+++ b/templates/depth.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>全息3D图像查看器深度</title>
+    <script>
+        // 全息显示参数默认值配置
+        window.HOLOGRAPHY_DEFAULTS = {
+            // 全息显示参数
+            lineNumber: 19.61603,
+            obliquity: 0.101593,
+            deviation: 15.83299625,
+        };
+    </script>
     <style>
         body {
             margin: 0;
@@ -161,7 +170,7 @@
                 <h3>全息显示参数</h3>
                 <div class="control-item">
                     <label for="lineNumber">线数: <span id="lineNumberValue" class="value-display">19.61603</span></label>
-                    <input type="range" id="lineNumber" min="19" max="21" value="19.61603" step="0.00001">
+                    <input type="range" id="lineNumber" min="18" max="21" value="19.61603" step="0.00001">
                 </div>
                 <div class="control-item">
                     <label for="obliquity">倾斜度: <span id="obliquityValue" class="value-display">0.101593</span></label>
@@ -284,6 +293,25 @@
                 });
             });
         });
+        
+        // 将默认值应用到控件（供 init 调用）
+        function applyDefaults() {
+            const d = window.HOLOGRAPHY_DEFAULTS || {};
+
+            // 全息显示参数
+            if (d.lineNumber !== undefined) {
+                document.getElementById('lineNumber').value = d.lineNumber;
+                document.getElementById('lineNumberValue').textContent = d.lineNumber;
+            }
+            if (d.obliquity !== undefined) {
+                document.getElementById('obliquity').value = d.obliquity;
+                document.getElementById('obliquityValue').textContent = d.obliquity;
+            }
+            if (d.deviation !== undefined) {
+                document.getElementById('deviation').value = d.deviation;
+                document.getElementById('deviationValue').textContent = d.deviation;
+            }
+        }
         // WebGL上下文和着色器程序
         let gl;
         let program;
@@ -667,6 +695,9 @@
             setupGeometry();
             setupControls();
             
+            // 应用文件顶部的默认值配置
+            applyDefaults();
+
             gl.clearColor(0.0, 0.0, 0.0, 1.0);
             
             // 创建默认纹理


### PR DESCRIPTION
This pull request improves the configuration and initialization of default holography display parameters in both the `40.html` and `depth.html` templates. The main changes introduce a unified way to define and apply default values for key controls, and slightly adjust the allowed range for the "lineNumber" parameter.

**Default parameter configuration and initialization:**

* Added a `<script>` block at the top of both `40.html` and `depth.html` to define `window.HOLOGRAPHY_DEFAULTS`, specifying default values for `lineNumber`, `obliquity`, and `deviation`. [[1]](diffhunk://#diff-ef4fe00905c9456a069af6f16d802126b63e592211b786e391f9cdd2e04db3edR7-R15) [[2]](diffhunk://#diff-e817468580525ba608fd7810e02927c0411ddc8b87d25f619203c98c772040fbR7-R15)
* Implemented an `applyDefaults()` function in both files to set the UI controls to these default values on initialization. [[1]](diffhunk://#diff-ef4fe00905c9456a069af6f16d802126b63e592211b786e391f9cdd2e04db3edR269-R287) [[2]](diffhunk://#diff-e817468580525ba608fd7810e02927c0411ddc8b87d25f619203c98c772040fbR296-R314)
* Called `applyDefaults()` during the initialization sequence to ensure controls reflect the configured defaults when the page loads. [[1]](diffhunk://#diff-ef4fe00905c9456a069af6f16d802126b63e592211b786e391f9cdd2e04db3edR585-R587) [[2]](diffhunk://#diff-e817468580525ba608fd7810e02927c0411ddc8b87d25f619203c98c772040fbR698-R700)

**Parameter range adjustment:**

* Changed the minimum value of the `lineNumber` range input from 19 to 18 in both templates, allowing a broader range of values for this parameter. [[1]](diffhunk://#diff-ef4fe00905c9456a069af6f16d802126b63e592211b786e391f9cdd2e04db3edL148-R157) [[2]](diffhunk://#diff-e817468580525ba608fd7810e02927c0411ddc8b87d25f619203c98c772040fbL164-R173)

Fixes #4 